### PR TITLE
Add idToken to access token claims

### DIFF
--- a/src/components/Auth0Context.svelte
+++ b/src/components/Auth0Context.svelte
@@ -9,7 +9,8 @@
         isAuthenticated,
         isLoading,
         authError,
-        userInfo
+        userInfo,
+        idToken
     } from './auth0';
 
     // props.
@@ -70,6 +71,9 @@
             // fetch the user info
             const user = await auth0.getUser();
             userInfo.set(user);
+            // fetch the token claims
+            const idTokenClaims = await auth0FromHook.getIdTokenClaims();
+            idToken.set(idTokenClaims.__raw);
             // automatically keep a curent token.
             refreshToken();
             tokenRefreshIntervalId = setInterval(refreshToken, refreshRate);

--- a/src/components/Auth0Context.svelte
+++ b/src/components/Auth0Context.svelte
@@ -72,7 +72,7 @@
             const user = await auth0.getUser();
             userInfo.set(user);
             // fetch the token claims
-            const idTokenClaims = await auth0FromHook.getIdTokenClaims();
+            const idTokenClaims = await auth0.getIdTokenClaims();
             idToken.set(idTokenClaims.__raw);
             // automatically keep a curent token.
             refreshToken();

--- a/src/components/auth0.js
+++ b/src/components/auth0.js
@@ -7,6 +7,7 @@ import { getContext } from 'svelte';
 export const isLoading = writable(true);
 export const isAuthenticated = writable(false);
 export const authToken = writable('');
+export const idToken = writable('');
 export const userInfo = writable({});
 export const authError = writable(null);
 


### PR DESCRIPTION
Hi dopry,
I found this svelte-auth0 library really helpful. Thanks for building and sharing it. I am using it alongside Dgraph and Dgraph requires access to the idTokenClaims. I created another store for it and it worked for me. I include my change here in case it is useful to others. If you decide not to merge, I understand as I don't think it is a common pattern/use case. 