### PR TITLE
fix: add missing error handling for createAuth0Client

### DIFF
--- a/src/components/Auth0Context.svelte
+++ b/src/components/Auth0Context.svelte
@@ -34,7 +34,11 @@
     let tokenRefreshIntervalId;
 
     // getContext doesn't seem to return a value in OnMount, so we'll pass the auth0Promise around by reference.
-    let auth0Promise = createAuth0Client({domain, client_id, audience});
+    let auth0Promise = createAuth0Client({domain, client_id, audience}).catch(e=>{
+        // Handle promise rejections
+        isLoading.set(false);
+        authError.set(e);
+    });
     setContext(AUTH0_CONTEXT_CLIENT_PROMISE, auth0Promise);
 
 


### PR DESCRIPTION
Add `catch` for `createAuth0Client` promise to handle rejections. The `catch` sets `isLoading` store to `false` and sets `authError` to the received promise error.