### PR TITLE
Check for 'state' in Auth0 redirect handling

### DIFF
--- a/src/components/Auth0Context.svelte
+++ b/src/components/Auth0Context.svelte
@@ -56,7 +56,7 @@
         }
 
         // if code then login success
-        if (params.has('code')) {
+        if (params.has('code') && params.has('state')) {
             // Let the Auth0 SDK do it's stuff - save some state, etc.
             const { appState } = await auth0.handleRedirectCallback();
             // Can be smart here and redirect to original path instead of root


### PR DESCRIPTION
Auth0Context.svelte currently calls auth0.handleRedirectCallback() whenever the URL contains a code parameter. The Auth0 SPA SDK verifies that the state parameter matches the stored transaction; when state is missing, handleRedirectCallback rejects with “Invalid state” [see here](https://github.com/auth0/auth0-spa-js/blob/f8172a7ddcb26a6efc1af74c9378076ca0f0f4c1/src/Auth0Client.ts#L283).

Auth0’s built-in email verification links illustrate the problem. After the user clicks the verification link (e.g. they get redirected to https://<domain>/?supportSignUp=true&supportForgotPassword=true&message=Your%20email%20was%20verified...&success=true&code=success), Auth0 appends code=success but no state. Auth0Context, consequently throws “Invalid state” on every verified visit even though the user isn’t returning from a login redirect.

Auth0Context.svelte now checks for both code and state before calling auth0.handleRedirectCallback().
If code is present but state is missing, we skip the callback so the page can load normally.